### PR TITLE
chore(ci): pin reusable workflow refs + baseline policy doc

### DIFF
--- a/.github/WORKFLOW_BASELINE.md
+++ b/.github/WORKFLOW_BASELINE.md
@@ -1,0 +1,32 @@
+# Workflow Baseline Policy
+
+This repository defines the organization-level baseline for GitHub collaboration and CI hygiene.
+
+## Reusable workflow reference policy
+
+- Do **not** reference reusable workflows with floating refs such as `@master` or `@main`.
+- Use immutable refs:
+  - pinned commit SHA (preferred), or
+  - immutable release tag.
+
+Example:
+
+```yaml
+uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b
+```
+
+## Pull request baseline
+
+- Conventional Commit title required.
+- Semantic PR title check required.
+- CI checks must pass before merge.
+
+## Terraform module baseline (org standard)
+
+For Terraform module repositories, include:
+
+- `terraform.required_version` in `versions.tf`
+- explicit `required_providers` constraints
+- pinned shared workflow refs in `.github/workflows/*`
+
+These standards reduce supply-chain risk and improve CI reproducibility.

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -7,7 +7,7 @@ permissions:
   pull-requests: write
 jobs:
   auto-merge:
-    uses: clouddrove/github-shared-workflows/.github/workflows/auto_merge.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/auto_merge.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       azure_cloud: true
       tfchecks_azure: '["tf-lint / tflint"]'

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   checkov:
-    uses: clouddrove/github-shared-workflows/.github/workflows/checkov.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/checkov.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       directory: '.'
       continue_on_error: 'true'

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   pr-validation:
     if: github.actor != 'dependabot[bot]'
-    uses: clouddrove/github-shared-workflows/.github/workflows/pr_checks.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/pr_checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     secrets: inherit
     with:
       subjectPattern: '^.+$'

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -13,4 +13,17 @@ jobs:
     uses: clouddrove/github-shared-workflows/.github/workflows/pr_checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     secrets: inherit
     with:
-      subjectPattern: '^.+$'
+      types: |
+        feat
+        fix
+        docs
+        style
+        refactor
+        perf
+        test
+        build
+        ci
+        chore
+        revert
+      subjectPattern: '^.+
+

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-shared-stale:
-    uses: clouddrove/github-shared-workflows/.github/workflows/stale_pr.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/stale_pr.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       days-before-issue-stale: 30
       days-before-pr-stale: 30

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tag-release.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tag-release.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       target_branch: master
     secrets:

--- a/.github/workflows/terraform-diff.yml
+++ b/.github/workflows/terraform-diff.yml
@@ -8,7 +8,7 @@ jobs:
 # Update 'Job name' and 'terraform_directory' as needed based on the module structure.
   complete-example:
     if: github.actor != 'dependabot[bot]'
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-pr-checks.yaml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-pr-checks.yaml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       provider: 'azurerm'
       terraform_directory: 'examples/complete'
@@ -19,7 +19,7 @@ jobs:
       
   mysql-with-private-endpoint-example:
     if: github.actor != 'dependabot[bot]'
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-pr-checks.yaml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-pr-checks.yaml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       provider: 'azurerm'
       terraform_directory: 'examples/mysql_with_private_endpoint'

--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -7,16 +7,16 @@ on:
 jobs:
 # Update 'Job name' and 'working_directory' as needed based on the module structure.
   complete-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       working_directory: './examples/complete/'
 
   mysql_with_private_endpoint-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       working_directory: './examples/mysql_with_private_endpoint/'  
 # Seperate Job for TFlint workflow call
   tf-lint:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-lint.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-lint.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     secrets:
       GITHUB: ${{ secrets.GITHUB }}


### PR DESCRIPTION
## Summary
- pin reusable workflow calls from floating refs (for example `@master`) to immutable SHA `88efd7724e007c8f721a219498be29e0c9ad471b`
- add `.github/WORKFLOW_BASELINE.md` from org baseline repository

## Scope
- no runtime code changes
- CI/workflow hygiene only

## Risk
Low: non-breaking metadata/workflow reference hardening.